### PR TITLE
Adding Hong Kong stock support to GoogleWeb

### DIFF
--- a/lib/Finance/Quote/GoogleWeb.pm
+++ b/lib/Finance/Quote/GoogleWeb.pm
@@ -84,8 +84,8 @@ sub googleweb {
       $tree = HTML::TreeBuilder->new;
       if ($tree->parse_content($body)) {
         #
-        # Get link with exchange appended (MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS)
-        $taglink = $tree->look_down(_tag => 'a', href => qr!^./quote/$ucstock:(MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS)!);
+        # Get link with exchange appended (MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS|HKG)
+        $taglink = $tree->look_down(_tag => 'a', href => qr!^./quote/$ucstock:(MUTF|NYSE|NASDAQ|NYSEAMERICAN|BATS|HKG)!);
         if ($taglink) {
           $link = $taglink->attr('href');
           $link =~ s|\./quote|quote|;

--- a/lib/Finance/Quote/GoogleWeb.pm
+++ b/lib/Finance/Quote/GoogleWeb.pm
@@ -35,20 +35,28 @@ use if DEBUG, 'Smart::Comments', '###';
 
 my $GOOGLE_URL = 'https://www.google.com/finance/';
 
-sub methods {
-  return (googleweb => \&googleweb,
-          bats      => \&googleweb,
-          nyse      => \&googleweb,
-          nasdaq    => \&googleweb);
+our $DISPLAY    = 'GoogleWeb - Scrapes www.google.com/finance/';
+our @LABELS     = qw/symbol name last date currency method/;
+our $METHODHASH = {subroutine => \&googleweb,
+                   display    => $DISPLAY, 
+                   labels     => \@LABELS};
+
+sub methodinfo {
+    return ( 
+        googleweb => $METHODHASH,
+        bats      => $METHODHASH,
+        nyse      => $METHODHASH,
+        nasdaq    => $METHODHASH,
+    );
 }
 
-our @labels = qw/symbol name last date currency method/;
+sub labels {
+  my %m = methodinfo();
+  return map {$_ => [@{$m{$_}{labels}}] } keys %m;
+}
 
-sub labels { 
-  return (googleweb => \@labels,
-          bats      => \@labels,
-          nyse      => \@labels,
-          nasdaq    => \@labels); 
+sub methods {
+  my %m = methodinfo(); return map {$_ => $m{$_}{subroutine} } keys %m;
 }
 
 sub googleweb {


### PR DESCRIPTION
With the recent and repeated problems with YahooJson, I think the GoogleWeb option is becoming more and more viable and valuable. Here's a very small tweak for it to handle stock traded in the Hong Kong Stock Exchange (HKEX), with ticket symbols such as "2828", "0700", etc.

The logic today is to fetch from a Google Finance web URL for a ticker such as "TSLA", and then find an "A" anchor in the format of something like "TSLA:NASDAQ" and then fetch that page. There is a limited set of "exchanges" that are supported there, and I just added "HKG". I'm sure there are others (like Toronto TSX, London LON, etc.), if the reviewer(s) are willing, please feel free to add those too.

Thank you for the good work!